### PR TITLE
docs: clarify GitHub integration setup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Or with a specific question:
 claude "What does this repository do?"
 ```
 
+## GitHub Integration Setup
+
+To enable Claude Code GitHub integration for automated issue and PR responses:
+
+1. **Add API Key to Repository Secrets**:
+   - Go to your repository's Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `ANTHROPIC_API_KEY`
+   - Value: Your API key from [Anthropic Console](https://console.anthropic.com/keys)
+
+2. **Add GitHub Workflow**:
+   - Copy the `claude.yml` workflow file to `.github/workflows/claude.yml` in your repository
+   - This enables Claude to respond to `@claude` mentions in issues and pull requests
+
 ## Troubleshooting
 
 If you see a warning about missing API key when the Codespace starts:


### PR DESCRIPTION
Resolves #1

Added a new "GitHub Integration Setup" section to the README that clarifies:

1. **Repository Secrets**: ANTHROPIC_API_KEY must be added to repository secrets (Settings → Secrets and variables → Actions)
2. **Workflow File**: claude.yml file needs to be copied to `.github/workflows/claude.yml` to enable `@claude` mentions in issues and PRs

Generated with [Claude Code](https://claude.ai/code)